### PR TITLE
change invoke to construct in stubs

### DIFF
--- a/src/Stubs/WebhookJobs.stub
+++ b/src/Stubs/WebhookJobs.stub
@@ -4,7 +4,7 @@ namespace App\WebhookJobs;
 
 class {{class}}
 {
-    public function __invoke($eventPayload) {
+    public function __construct($eventPayload) {
     	//
     }
 }


### PR DESCRIPTION
Hi Joe,
Thanks for this great package! There is one small issue though.. the files that are generated under webhookjobs get created as follows:
```
<?php
namespace App\WebhookJobs;
class NetAuthorizeCustomerSubscriptionExpiring
{
    public function __invoke($eventPayload) {
        //
    }
}
```
They all should have
```
public function  __construct($eventPayload){
}
```
Thanks again for your work on this!
Shankar.    